### PR TITLE
fix doctests for pari 2.17

### DIFF
--- a/autogen/doc.py
+++ b/autogen/doc.py
@@ -289,7 +289,7 @@ def get_rest_doc(function):
         >>> from autogen.doc import get_rest_doc
         >>> print(get_rest_doc("teichmuller"))
         Teichmüller character of the :math:`p`-adic number :math:`x`, i.e. the unique
-        :math:`(p-1)`-th root of unity congruent to :math:`x / p^{v_p(x)}` modulo :math:`p`...
+        :math:`(p-1)`-th root of unity congruent to :math:`x / p^{v_...(x)}` modulo :math:`p`...
 
     ::
 
@@ -300,24 +300,24 @@ def get_rest_doc(function):
         .. MATH::
         <BLANKLINE>
             f(x) = \exp (-i\pi/24).\eta ((x+1)/2)/\eta (x) {such that}
-            j = (f^{24}-16)^3/f^{24},
+            j = (f^{24}-16)^.../f^{24},
         <BLANKLINE>
         where :math:`j` is the elliptic :math:`j`-invariant (see the function :literal:`ellj`).
         If :math:`flag = 1`, returns
         <BLANKLINE>
         .. MATH::
         <BLANKLINE>
-            f_1(x) = \eta (x/2)/\eta (x) {such that}
-            j = (f_1^{24}+16)^3/f_1^{24}.
+            f_...(x) = \eta (x/2)/\eta (x) {such that}
+            j = (f_...^{24}+16)^.../f_...^{24}.
         <BLANKLINE>
         Finally, if :math:`flag = 2`, returns
         <BLANKLINE>
         .. MATH::
         <BLANKLINE>
-            f_2(x) = \sqrt{2}\eta (2x)/\eta (x) {such that}
-            j = (f_2^{24}+16)^3/f_2^{24}.
+            f_...(x) = \sqrt{2}\eta (2x)/\eta (x) {such that}
+            j = (f_...^{24}+16)^.../f_...^{24}.
         <BLANKLINE>
-        Note the identities :math:`f^8 = f_1^8+f_2^8` and :math:`ff_1f_2 = \sqrt2`.
+        Note the identities :math:`f^... = f_...^...+f_...^...` and :math:`ff_...f_... = \sqrt2`.
 
 
     ::
@@ -333,7 +333,7 @@ def get_rest_doc(function):
         .. MATH::
         <BLANKLINE>
             \sum
-            (x_i or y_i) 2^i
+            (x_... or y_...) 2^...
         <BLANKLINE>
         See ``bitand`` (in the PARI manual) for the behavior for negative arguments.
     """

--- a/cypari2/gen.pyx
+++ b/cypari2/gen.pyx
@@ -902,6 +902,7 @@ cdef class Gen(Gen_base):
 
         >>> x = pari('x')
 
+        >>> pari.setrand(1)
         >>> (x**2 - 65).bnfinit().bnf_get_fu()
         [Mod(x - 8, x^2 - 65)]
         >>> (x**4 - x**2 + 1).bnfinit().bnf_get_fu()
@@ -951,6 +952,7 @@ cdef class Gen(Gen_base):
         >>> import warnings
         >>> with warnings.catch_warnings(record=True) as w:
         ...     warnings.simplefilter('always')
+        ...     pari.setrand(1)
         ...     funits = (x**2 - 65).bnfinit().bnfunit()
         ...     assert len(w) == 1
         ...     assert issubclass(w[0].category, DeprecationWarning)

--- a/cypari2/pari_instance.pyx
+++ b/cypari2/pari_instance.pyx
@@ -235,9 +235,9 @@ Verify that ``nfroots()`` (which has an unusual signature with a
 non-default argument following a default argument) works:
 
 >>> pari.nfroots(x='x^4 - 1')
-[-1, 1]
+[-1, 1]...
 >>> pari.nfroots(pari.nfinit('t^2 + 1'), "x^4 - 1")
-[-1, 1, Mod(-t, t^2 + 1), Mod(t, t^2 + 1)]
+[-1, 1, Mod(-t, t^2 + 1), Mod(t, t^2 + 1)]...
 
 Reset default precision for the following tests:
 


### PR DESCRIPTION
Fix some doctests to work with pari 2.17; should still work on older pari.

The remaining failures are in testing `prec_bits_to_pari()` and `prec_pari_to_bits()` but IMHO we should be removing those functions.